### PR TITLE
Handle focus divider from command palette

### DIFF
--- a/app.go
+++ b/app.go
@@ -1950,7 +1950,7 @@ func (a *Dv) focusDividerFromPalette() {
 func (a *Dv) exitDividerFocus() {
 	a.dividerFocusRequested = false
 	target := a.focusReturnID
-	if target == "" || target == diffSplitPaneID {
+	if isInvalidDividerReturnTarget(target) {
 		target = diffViewerScrollID
 	}
 	t.RequestFocus(target)
@@ -2004,10 +2004,21 @@ func (a *Dv) syncFocusState(ctx t.BuildContext) {
 
 func (a *Dv) dividerReturnTarget() string {
 	target := a.lastNonDividerFocus
-	if target == "" || target == diffSplitPaneID {
+	if isInvalidDividerReturnTarget(target) {
 		target = diffViewerScrollID
 	}
 	return target
+}
+
+// We can't assume that the previous widget that was focused is still available (e.g. command palette).
+func isInvalidDividerReturnTarget(target string) bool {
+	if target == "" || target == diffSplitPaneID {
+		return true
+	}
+	if target == diffCommandPaletteID {
+		return true
+	}
+	return strings.HasPrefix(target, diffCommandPaletteID+"-")
 }
 
 func dividerFocusForeground(theme t.ThemeData) t.ColorProvider {

--- a/app_test.go
+++ b/app_test.go
@@ -1687,6 +1687,39 @@ func TestDv_FocusDividerNoopWhenSidebarHidden(tt *testing.T) {
 	require.False(tt, app.dividerFocusRequested)
 }
 
+func TestDv_DividerReturnTargetFallsBackFromCommandPalette(tt *testing.T) {
+	app := newTestDv(&scriptedDiffProvider{repoRoot: "/tmp/repo"}, false)
+	app.lastNonDividerFocus = diffCommandPaletteID
+
+	require.Equal(tt, diffViewerScrollID, app.dividerReturnTarget())
+}
+
+func TestDv_DividerReturnTargetFallsBackFromCommandPaletteInput(tt *testing.T) {
+	app := newTestDv(&scriptedDiffProvider{repoRoot: "/tmp/repo"}, false)
+	app.lastNonDividerFocus = diffCommandPaletteID + "-input"
+
+	require.Equal(tt, diffViewerScrollID, app.dividerReturnTarget())
+}
+
+func TestDv_FocusDividerFromPaletteUsesViewerFallbackTarget(tt *testing.T) {
+	app := newTestDv(&scriptedDiffProvider{repoRoot: "/tmp/repo"}, false)
+	app.lastNonDividerFocus = diffCommandPaletteID + "-input"
+
+	app.focusDividerFromPalette()
+
+	require.True(tt, app.dividerFocusRequested)
+	require.Equal(tt, diffViewerScrollID, app.focusReturnID)
+}
+
+func TestIsInvalidDividerReturnTarget(tt *testing.T) {
+	require.True(tt, isInvalidDividerReturnTarget(""))
+	require.True(tt, isInvalidDividerReturnTarget(diffSplitPaneID))
+	require.True(tt, isInvalidDividerReturnTarget(diffCommandPaletteID))
+	require.True(tt, isInvalidDividerReturnTarget(diffCommandPaletteID+"-input"))
+	require.True(tt, isInvalidDividerReturnTarget(diffCommandPaletteID+"-list"))
+	require.False(tt, isInvalidDividerReturnTarget(diffViewerScrollID))
+}
+
 func TestDv_RefreshLoadsCurrentBranch(tt *testing.T) {
 	app := newTestDv(&scriptedDiffProvider{
 		repoRoot: "/tmp/repo",


### PR DESCRIPTION
Fixes #2 

On pressing escape when the sidebar divider is focused, focus is returned to the previously focused widget. If the divider was focused via command palette, this approach doesn't work, so we re-focus the scrollable diff instead.

I think ultimately I may just rework this to work similarly to the diff split view divider (just use keybinds to increase/decrease size). Perhaps ctrl+shift+h to shift divider left and ctrl+shift+l to shift it right. It's a little weird having 2 approaches like we do now.